### PR TITLE
修复dockerfile安装字体命令

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ MAINTAINER luojiarui luojiarui2@163.com
 
 # 在docker中添加fontconfig 和 字体
 # 该过程比较慢，可以参考https://lhalcyon.com/alpine-font-issue/
-ENV LANG en_US.UTF-8RUN apk add --update ttf-dejavu fontconfig && rm -rf /var/cache/apk/*
+ENV LANG en_US.UTF-8
+RUN apk add --update ttf-dejavu fontconfig  && rm -rf /var/cache/apk/*
 
 
 # 将当前目录下的jar包复制到docker容器的/目录下


### PR DESCRIPTION
使用原dockerfile build之后会报错，无法正确的提取文本并上传至es。
检查发现dockerfile里的两条命令之间似乎缺少了一个换行。
加入换行后可以正常安装字体，构建的image可以正常运行。

顺带一提，这在wsl下是没问题的，只是添加了一个用不到的环境变量；只有在（部分）linux系统上才必须安装这个字体，继而引起问题。
